### PR TITLE
refactor of httpTracker test using a fake endpoint made with HttpMock.Net

### DIFF
--- a/TorrentCore.Test/TorrentCore.Test.csproj
+++ b/TorrentCore.Test/TorrentCore.Test.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HttpMock.Net" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="Moq" Version="4.10.1" />


### PR DESCRIPTION
The purpose of this change is to change httpTracker test in order to use a "real" http endpoint simulating a tracker.