### PR TITLE
UPnP support

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,5 +1,0 @@
-<configuration>
-  <packageSources>
-    <add key="CoreFxLab" value="https://dotnet.myget.org/F/dotnet-corefxlab/" />
-  </packageSources>
-</configuration>

--- a/TorrentCore.Cli/Program.cs
+++ b/TorrentCore.Cli/Program.cs
@@ -45,7 +45,7 @@ namespace TorrentCore.Cli
                 {
                     IsRequired = true,
                 },
-                new Option<bool>(new[] { "v", "verbose" }, "Show detailed logging information."),
+                new Option<bool>(new[] { "-v", "--verbose" }, "Show detailed logging information."),
                 new Argument<FileInfo>("--input", "Path of torrent file to download.")
                 {
                     Arity = ArgumentArity.ExactlyOne,

--- a/TorrentCore.Cli/Program.cs
+++ b/TorrentCore.Cli/Program.cs
@@ -6,50 +6,62 @@
 // LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
-using System.Diagnostics;
+using System.CommandLine.Builder;
+using System.CommandLine.Hosting;
+using System.CommandLine.NamingConventionBinder;
+using System.CommandLine.Parsing;
 using System.IO;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Serilog;
 using TorrentCore.Extensions.ExtensionProtocol;
 using TorrentCore.Extensions.PeerExchange;
 using TorrentCore.Extensions.SendMetadata;
 using TorrentCore.Modularity;
-using TorrentCore.Web;
 
 namespace TorrentCore.Cli
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
-            int port = 5000;
-            int uiPort = 5001;
-            bool runWebUi = false;
-            string input = null;
-            string output = null;
-            bool verbose = false;
-            ArgumentSyntax.Parse(args, syntax =>
+            return await BuildCommandLine()
+                .UseHost(host => host.UseSerilog())
+                .UseDefaults()
+                .Build()
+                .InvokeAsync(args);
+        }
+
+        private static CommandLineBuilder BuildCommandLine()
+        {
+            var root = new RootCommand()
             {
-                syntax.DefineOption("p|port", ref port, "Port to listen for incoming connections on.");
-                syntax.DefineOption("o|output", ref output, "Path to save downloaded files to.");
-                syntax.DefineOption("v|verbose", ref verbose, "Show detailed logging information.");
-                var uiPortArgument = syntax.DefineOption("ui", ref uiPort, false, "Run a web UI, optionally specifying the port to listen on (default: 5001).");
-                runWebUi = uiPortArgument.IsSpecified;
+                new Option<int>(new[] { "-p", "--port" }, "Port to listen for incoming connections on.")
+                {
+                    IsRequired = true,
+                },
+                new Option<DirectoryInfo>(new[] { "-o", "--output" }, "Path to save downloaded files to.")
+                {
+                    IsRequired = true,
+                },
+                new Option<bool>(new[] { "v", "verbose" }, "Show detailed logging information."),
+                new Argument<FileInfo>("--input", "Path of torrent file to download.")
+                {
+                    Arity = ArgumentArity.ExactlyOne,
+                },
+            };
+            root.Handler = CommandHandler.Create<Options>(RunAsync);
+            return new CommandLineBuilder(root);
+        }
 
-                syntax.DefineParameter("input", ref input, "Path of torrent file to download.");
-            });
-
+        private static async Task<int> RunAsync(Options options)
+        {
             var builder = TorrentClientBuilder.CreateDefaultBuilder();
 
             // Configure logging
             Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Is(verbose ? Serilog.Events.LogEventLevel.Debug : Serilog.Events.LogEventLevel.Information)
+                .MinimumLevel.Is(options.Verbose ? Serilog.Events.LogEventLevel.Debug : Serilog.Events.LogEventLevel.Information)
                 .Enrich.FromLogContext()
                 .WriteTo.Console()
                 .CreateLogger();
@@ -57,7 +69,7 @@ namespace TorrentCore.Cli
             builder.ConfigureServices(services => services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true)));
 
             // Listen for incoming connections on the specified port
-            builder.UsePort(port);
+            builder.UsePort(options.Port);
 
             // Add extension protocol
             builder.ConfigureServices(services =>
@@ -72,15 +84,9 @@ namespace TorrentCore.Cli
                 });
             });
 
-            var client = builder.Build();
+            using var client = builder.Build();
 
-            ////if (runWebUi)
-            ////{
-            ////    var uri = client.EnableWebUI(uiPort);
-            ////    Console.WriteLine($"Web UI started at {uri}");
-            ////}
-
-            var download = client.Add(input, output);
+            var download = client.Add(options.Input.FullName, options.Output.FullName);
             download.Start();
 
             Console.WriteLine("Downloading...");
@@ -90,14 +96,33 @@ namespace TorrentCore.Cli
                 timer.Elapsed += (o, e) => LogStatus(download);
                 timer.Start();
 
-                download.WaitForDownloadCompletionAsync().Wait();
+                try
+                {
+                    await download.WaitForDownloadCompletionAsync();
+                }
+                catch (TaskCanceledException)
+                {
+                    return -1;
+                }
             }
-            Console.ReadKey();
+
+            return 0;
         }
 
         private static void LogStatus(TorrentDownload download)
         {
             Console.WriteLine($"{download.State} ({download.Progress:P})");
+        }
+
+        private class Options
+        {
+            public int Port { get; set; }
+
+            public DirectoryInfo Output { get; set; }
+
+            public bool Verbose { get; set; }
+
+            public FileInfo Input { get; set; }
         }
     }
 }

--- a/TorrentCore.Cli/Program.cs
+++ b/TorrentCore.Cli/Program.cs
@@ -33,11 +33,13 @@ namespace TorrentCore.Cli
             string input = null;
             string output = null;
             bool verbose = false;
+            bool upnp = false;
             ArgumentSyntax.Parse(args, syntax =>
             {
                 syntax.DefineOption("p|port", ref port, "Port to listen for incoming connections on.");
                 syntax.DefineOption("o|output", ref output, "Path to save downloaded files to.");
                 syntax.DefineOption("v|verbose", ref verbose, "Show detailed logging information.");
+                syntax.DefineOption("u|upnp", ref upnp, "Use UPnP for port forwarding.");
                 var uiPortArgument = syntax.DefineOption("ui", ref uiPort, false, "Run a web UI, optionally specifying the port to listen on (default: 5001).");
                 runWebUi = uiPortArgument.IsSpecified;
 
@@ -52,6 +54,10 @@ namespace TorrentCore.Cli
 
             // Listen for incoming connections on the specified port
             builder.UsePort(port);
+
+            // If upnp is selected use it.
+            if (upnp)
+                builder.AddUPnP();
 
             // Add extension protocol
             builder.ConfigureServices(services =>

--- a/TorrentCore.Cli/Program.cs
+++ b/TorrentCore.Cli/Program.cs
@@ -45,6 +45,7 @@ namespace TorrentCore.Cli
                 {
                     IsRequired = true,
                 },
+                new Option<bool>(new[] { "-u", "--upnp" }, "Use UPnP for port forwarding."),
                 new Option<bool>(new[] { "-v", "--verbose" }, "Show detailed logging information."),
                 new Argument<FileInfo>("--input", "Path of torrent file to download.")
                 {
@@ -72,7 +73,7 @@ namespace TorrentCore.Cli
             builder.UsePort(options.Port);
 
             // If upnp is selected use it.
-            if (upnp)
+            if (options.UPnP)
                 builder.AddUPnP();
 
             // Add extension protocol
@@ -116,6 +117,8 @@ namespace TorrentCore.Cli
             public int Port { get; set; }
 
             public DirectoryInfo Output { get; set; }
+
+            public bool UPnP { get; set; }
 
             public bool Verbose { get; set; }
 

--- a/TorrentCore.Cli/Program.cs
+++ b/TorrentCore.Cli/Program.cs
@@ -96,14 +96,7 @@ namespace TorrentCore.Cli
                 timer.Elapsed += (o, e) => LogStatus(download);
                 timer.Start();
 
-                try
-                {
-                    await download.WaitForDownloadCompletionAsync();
-                }
-                catch (TaskCanceledException)
-                {
-                    return -1;
-                }
+                await download.WaitForDownloadCompletionAsync();
             }
 
             return 0;

--- a/TorrentCore.Cli/TorrentCore.Cli.csproj
+++ b/TorrentCore.Cli/TorrentCore.Cli.csproj
@@ -12,6 +12,10 @@
     <DocumentationFile>bin\Debug\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Visible="false" />
   </ItemGroup>

--- a/TorrentCore.Cli/TorrentCore.Cli.csproj
+++ b/TorrentCore.Cli/TorrentCore.Cli.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170729-1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22114.1" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/TorrentCore.sln
+++ b/TorrentCore.sln
@@ -1,14 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5BD8F3F0-5E3F-40CB-9534-CA78C50E88EF}"
 	ProjectSection(SolutionItems) = preProject
 		.travis.yml = .travis.yml
 		Directory.build.props = Directory.build.props
 		LICENSE = LICENSE
-		NuGet.config = NuGet.config
 		README.md = README.md
 		stylecop.json = stylecop.json
 		StyleCopRules.ruleset = StyleCopRules.ruleset

--- a/TorrentCore/TorrentClientBuilder.cs
+++ b/TorrentCore/TorrentClientBuilder.cs
@@ -89,6 +89,16 @@ namespace TorrentCore
         }
 
         /// <summary>
+        /// Add UPnP port forwarding feature.
+        /// </summary>
+        /// <returns>TorrentClientBuilder.</returns>
+        public TorrentClientBuilder AddUPnP()
+        {
+            _services.Configure<LocalTcpConnectionOptions>(options => options.UseUPnP = true);
+            return this;
+        }
+
+        /// <summary>
         /// Sets up a default Torrent Client using the TCP transport protocol and the BitTorrent application protocol.
         /// </summary>
         /// <returns>Builder configured to construct a default torrent client.</returns>

--- a/TorrentCore/TorrentClientSettings.cs
+++ b/TorrentCore/TorrentClientSettings.cs
@@ -21,12 +21,18 @@ namespace TorrentCore
             PeerId = PeerId.CreateNew();
             ListenPort = 6881;
             AdapterAddress = IPAddress.Any;
+            UseUPnP = false;
         }
 
         /// <summary>
         /// Gets or sets the Peer ID for the local client.
         /// </summary>
         public PeerId PeerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use UPnP for port forwarding.
+        /// </summary>
+        public bool UseUPnP { get; set; }
 
         /// <summary>
         /// Gets or sets the port to listen for incoming connections on.

--- a/TorrentCore/TorrentCore.csproj
+++ b/TorrentCore/TorrentCore.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="Open.NAT.Core" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/TorrentCore/TorrentCore.csproj
+++ b/TorrentCore/TorrentCore.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Open.NAT.Core" Version="2.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />

--- a/TorrentCore/Transport/IUPnPClient.cs
+++ b/TorrentCore/Transport/IUPnPClient.cs
@@ -1,0 +1,16 @@
+﻿// This file is part of TorrentCore.
+//   https://torrentcore.org
+// Copyright (c) Samuel Fisher.
+//
+// Licensed under the GNU Lesser General Public License, version 3. See the
+// LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace TorrentCore.Transport
+{
+    public interface IUPnPClient
+    {
+        Task TryAddPortMappingAsync(int port);
+    }
+}

--- a/TorrentCore/Transport/Tcp/LocalTcpConnectionOptions.cs
+++ b/TorrentCore/Transport/Tcp/LocalTcpConnectionOptions.cs
@@ -28,5 +28,10 @@ namespace TorrentCore.Transport.Tcp
         /// Gets or sets the address of the local adapter used for connections.
         /// </summary>
         public IPAddress BindAddress { get; set; } = IPAddress.Any;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use UPnP for port forwarding.
+        /// </summary>
+        public bool UseUPnP { get; set; }
     }
 }

--- a/TorrentCore/Transport/Tcp/TcpTransportProtocol.cs
+++ b/TorrentCore/Transport/Tcp/TcpTransportProtocol.cs
@@ -27,6 +27,7 @@ namespace TorrentCore.Transport.Tcp
     {
         private readonly ILogger<TcpTransportProtocol> _logger;
         private readonly ConcurrentBag<TcpTransportStream> _streams;
+        private readonly IUPnPClient _uPnPClient;
 
         private TcpListener _listener;
 
@@ -40,6 +41,7 @@ namespace TorrentCore.Transport.Tcp
             _logger = logger;
             _streams = new ConcurrentBag<TcpTransportStream>();
             Port = options.Value.Port;
+            _uPnPClient = new TcpTransportUPnPClient(options.Value.UseUPnP);
             LocalBindAddress = options.Value.BindAddress ?? IPAddress.Any;
             RateLimiter = new RateLimiter();
         }
@@ -108,6 +110,8 @@ namespace TorrentCore.Transport.Tcp
             // If port=0 was supplied, set the actual port we are listening on.
             Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
             ListenForIncomingConnections();
+
+            _uPnPClient.TryAddPortMappingAsync(Port);
         }
 
         /// <summary>

--- a/TorrentCore/Transport/Tcp/TcpTransportUPnPClient.cs
+++ b/TorrentCore/Transport/Tcp/TcpTransportUPnPClient.cs
@@ -1,0 +1,42 @@
+﻿// This file is part of TorrentCore.
+//   https://torrentcore.org
+// Copyright (c) Samuel Fisher.
+//
+// Licensed under the GNU Lesser General Public License, version 3. See the
+// LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Open.Nat;
+
+namespace TorrentCore.Transport.Tcp
+{
+    class TcpTransportUPnPClient : IUPnPClient
+    {
+        private bool _useUPnP;
+
+        public TcpTransportUPnPClient(bool useUPnP)
+        {
+            _useUPnP = useUPnP;
+        }
+
+        public async Task TryAddPortMappingAsync(int port)
+        {
+            if (!_useUPnP)
+                return;
+
+            try
+            {
+                var discoverer = new NatDiscoverer();
+                var cts = new CancellationTokenSource(10000);
+
+                var device = await discoverer.DiscoverDeviceAsync(PortMapper.Upnp, cts);
+                await device.CreatePortMapAsync(new Mapping(Protocol.Tcp, port, port, "TorrentCore"));
+            }
+            catch
+            {
+                // Do nothing
+            }
+        }
+    }
+}


### PR DESCRIPTION
If feature is added in client configuration, automatically open port just when TCP transport start listening. It uses Open.Nat library for UPnP functionality.